### PR TITLE
Fix disappearing chart

### DIFF
--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -33,7 +33,6 @@ Page {
     }
 
     onVisibleChanged: {
-        console.debug("Visible:",visible)
         if(visible == true)
             stat.update()
     }

--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -32,6 +32,12 @@ Page {
         }
     }
 
+    onVisibleChanged: {
+        console.debug("Visible:",visible)
+        if(visible == true)
+            stat.update()
+    }
+
     SilicaFlickable {
         anchors.fill: parent
 


### PR DESCRIPTION
This is visible on Sony Xperia X running Sailfish X. When the default page - the chart - is shown, and the application is swiped into background, and then activated again, the chart disappears. This change makes the chart update itself every time it comes re-visible.